### PR TITLE
Improve Usecases

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Project Dependencies:
 - Android Studio
 - XCode (need to create iPhone 12 Simulator to run the Unit Tests)
 
-## iOS -> XCFramework generation:
+## iOS -> XCFramework generation
 
 For iOS part, the KMM library is distribute as a Swift Package.
 See [core/swiftpackage](./core/swiftpackage) folder. 
@@ -19,7 +19,7 @@ This is mandatory to have the latest changes available for iOS project on Swift.
 
 The iOS pipeline file, runs the `core:assembleXCFramework` task.
 
-## Android -> Navigation:
+## Android -> Navigation
 
 The Android Navigation follows the Graph and Sub-Graph principle:
 - The main navigator (App navigator) only knows how to go to a `feature route`.

--- a/core/src/commonMain/kotlin/com/mindera/people/auth/GetAuthenticatedUserUseCase.kt
+++ b/core/src/commonMain/kotlin/com/mindera/people/auth/GetAuthenticatedUserUseCase.kt
@@ -5,8 +5,8 @@ import co.touchlab.kermit.Logger
 class GetAuthenticatedUserUseCase(
     private val authRepository: AuthRepository,
     private val log: Logger
-) {
-    operator fun invoke(): User? =
+): () -> User? {
+    override operator fun invoke(): User? =
         authRepository.authenticated.also {
             log.i { "Authenticated user=($it)" }
         }

--- a/core/src/commonMain/kotlin/com/mindera/people/auth/SignInUseCase.kt
+++ b/core/src/commonMain/kotlin/com/mindera/people/auth/SignInUseCase.kt
@@ -6,8 +6,8 @@ import com.mindera.people.data.toError
 class SignInUseCase(
     private val authRepository: AuthRepository,
     private val log: Logger
-) {
-    operator fun invoke(user: User): Result<User> =
+): (User) -> Result<User> {
+    override operator fun invoke(user: User): Result<User> =
         runCatching { authRepository.authenticateUser(user) }
             .fold(onSuccess = { Result.success(user) },
                   onFailure = {

--- a/core/src/commonMain/kotlin/com/mindera/people/auth/SignOutUseCase.kt
+++ b/core/src/commonMain/kotlin/com/mindera/people/auth/SignOutUseCase.kt
@@ -6,8 +6,8 @@ import com.mindera.people.data.toError
 class SignOutUseCase(
     private val authRepository: AuthRepository,
     private val log: Logger
-) {
-    operator fun invoke(): Result<Unit> =
+): () -> Result<Unit> {
+    override operator fun invoke(): Result<Unit> =
         runCatching { authRepository.clearUser() }
             .fold(onSuccess = { Result.success(Unit) },
                   onFailure = {


### PR DESCRIPTION
Change the UseCases returning type to Lambdas, avoiding the auto-calling when instantiating the UseCase.